### PR TITLE
Minor cosmetic changes and cross-platform tests

### DIFF
--- a/src/main/java/uk/gov/dwp/gysp/pdf/PdfGenerator.java
+++ b/src/main/java/uk/gov/dwp/gysp/pdf/PdfGenerator.java
@@ -11,7 +11,6 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.dwp.gysp.pdf.processor.PdfGeneratorProcessor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +36,6 @@ public class PdfGenerator {
 	private float leftMarginOffset;
 	private float pageEndY;
 	private int pageIndex = 0;
-	private float pageStartY;
 
 	public PdfGenerator(final JsonNode json) {
 		this.json = json;
@@ -49,11 +47,11 @@ public class PdfGenerator {
 	}
 
 	private static InputStream getArialBoldFontStream() {
-		return PdfGeneratorProcessor.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/Roboto-Bold.ttf");
+		return PdfGenerator.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/Roboto-Bold.ttf");
 	}
 
 	private static InputStream getArialFontStream() {
-		return PdfGeneratorProcessor.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/Roboto-Regular.ttf");
+		return PdfGenerator.class.getResourceAsStream("/org/apache/pdfbox/resources/ttf/Roboto-Regular.ttf");
 	}
 
 	private void addFormAnswer(final JsonNode valueNode) throws IOException {
@@ -102,10 +100,9 @@ public class PdfGenerator {
 
 	private void initPageVars() {
 		final PDRectangle pageSize = this.currentPage.getMediaBox();
-		this.pageStartY = pageSize.getUpperRightY() - MARGIN;
 		this.pageEndY = pageSize.getLowerLeftY() + MARGIN;
 		this.leftMarginOffset = pageSize.getLowerLeftX() + MARGIN;
-		this.heightCounter = this.pageStartY;
+		this.heightCounter = pageSize.getUpperRightY() - MARGIN;
 	}
 
 	private void initPdfDocument() throws IOException {
@@ -152,7 +149,7 @@ public class PdfGenerator {
 			} else {
 				LOGGER.error("Bad node type found for json {}", json.toString());
 				throw new IllegalArgumentException(
-						String.format("Node type: %s for node %s is not currently supported when processing JSON Arrays",
+						String.format("Node type: '%s' is not currently supported when processing JSON Arrays",
 								element.getNodeType().name()));
 			}
 		}

--- a/src/test/java/uk/gov/dwp/gysp/pdf/PdfGeneratorTest.java
+++ b/src/test/java/uk/gov/dwp/gysp/pdf/PdfGeneratorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.dwp.gysp.pdf;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.ArrayUtils;
@@ -23,7 +22,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void emptyJsonReturnsPdf() throws JsonProcessingException, IOException {
+	public void emptyJsonReturnsPdf() throws IOException {
 		// Given
 		final int expectedPageNo = 1;
 		final JsonNode json = new ObjectMapper().readTree("{}");
@@ -36,7 +35,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void isTwoPagePdf() throws JsonProcessingException, IOException {
+	public void isTwoPagePdf() throws IOException {
 		// Given
 		final int expectedPageNo = 2;
 
@@ -59,7 +58,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContainsExpectedContentForEmbeddedArrayObjects() throws JsonProcessingException, IOException {
+	public void pdfContainsExpectedContentForEmbeddedArrayObjects() throws IOException {
 		// Given
 		final String objectName = "ArrayOfNos";
 		final String firstItemName = "First";
@@ -88,7 +87,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContainsExpectedContentForEmbeddedArrayValues() throws JsonProcessingException, IOException {
+	public void pdfContainsExpectedContentForEmbeddedArrayValues() throws IOException {
 		// Given
 		final String objectName = "ArrayOfNos";
 		final String firstItem = "One";
@@ -110,7 +109,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContainsExpectedContentForEmbeddedObject() throws JsonProcessingException, IOException {
+	public void pdfContainsExpectedContentForEmbeddedObject() throws IOException {
 		// Given
 		final String objectName = "Person";
 		final String name = "First Name";
@@ -130,7 +129,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContainsExpectedContentMultipleNodes() throws JsonProcessingException, IOException {
+	public void pdfContainsExpectedContentMultipleNodes() throws IOException {
 		// Given
 		final String firstFieldName = "First Name";
 		final String firstFieldValue = "Samba";
@@ -154,7 +153,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContainsExpectedContentSingleNode() throws JsonProcessingException, IOException {
+	public void pdfContainsExpectedContentSingleNode() throws IOException {
 		// Given
 		final String name = "First Name";
 		final String value = "Samba";
@@ -171,7 +170,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContentInExpectedOrder() throws JsonProcessingException, IOException {
+	public void pdfContentInExpectedOrder() throws IOException {
 		// Given
 		final int expectedNoLines = 6;
 
@@ -202,7 +201,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfIsGenerated() throws JsonProcessingException, IOException {
+	public void pdfIsGenerated() throws IOException {
 		// Given
 		final JsonNode json = new ObjectMapper().readTree("{\"First Name\":\"Samba\"}");
 		// When
@@ -212,7 +211,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void unusedPagesRemoved() throws JsonProcessingException, IOException {
+	public void unusedPagesRemoved() throws IOException {
 		// Given
 		final int expectedPageNo = 1;
 		final JsonNode json = new ObjectMapper().readTree("{\"First Name\":\"Samba\"}");
@@ -223,7 +222,7 @@ public class PdfGeneratorTest {
 	}
 
 	@Test
-	public void pdfContentIncludesUnicode() throws JsonProcessingException, IOException {
+	public void pdfContentIncludesUnicode() throws IOException {
 		// Given
 		final int expectedNoLines = 6;
 

--- a/src/test/java/uk/gov/dwp/gysp/pdf/ServiceControllerIT.java
+++ b/src/test/java/uk/gov/dwp/gysp/pdf/ServiceControllerIT.java
@@ -45,11 +45,11 @@ public class ServiceControllerIT {
 				.postForEntity(getPdfServiceApiEndpoint() + "/generatePdf", json, byte[].class);
 
 		// Then
-		assertEquals("Response status code not as expected", response.getStatusCode(), HttpStatus.OK);
+		assertEquals("Response status code not as expected", HttpStatus.OK, response.getStatusCode());
 		assertEquals("Response content type not as expected",
+				MediaType.APPLICATION_OCTET_STREAM_VALUE,
 				response.getHeaders().getContentType().getType() + "/"
-						+ response.getHeaders().getContentType().getSubtype(),
-				MediaType.APPLICATION_OCTET_STREAM_VALUE);
+						+ response.getHeaders().getContentType().getSubtype());
 
 		PDFParser pdfParser = new PDFParser(new RandomAccessBuffer(response.getBody()));
 		pdfParser.parse();
@@ -58,7 +58,7 @@ public class ServiceControllerIT {
 		// representation of the PDF document i.e. COSDocument object
 
 		String output = new PDFTextStripper().getText(pdfParser.getPDDocument());
-		String[] outputContents = output.split("\n");
+		String[] outputContents = output.split(System.lineSeparator());
 		assertEquals("Address not as expected", "address", outputContents[0]);
 		assertEquals("Building number not as expected", "buildingNumber", outputContents[1]);
 		assertEquals("Building number value not as expected", "100", outputContents[2]);

--- a/src/test/java/uk/gov/dwp/gysp/pdf/processor/PdfGeneratorProcessorTest.java
+++ b/src/test/java/uk/gov/dwp/gysp/pdf/processor/PdfGeneratorProcessorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.dwp.gysp.pdf.processor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.pdfbox.io.RandomAccessBuffer;
@@ -37,7 +36,7 @@ public class PdfGeneratorProcessorTest {
 
 	@Test
 	public void confirmPDFDocumentIsCreatedWithJSON()
-			throws JsonProcessingException, IOException, PdfGeneratorException {
+			throws IOException, PdfGeneratorException {
 		// Given
 		final JsonNode json = new ObjectMapper().readTree("{\"First Name\":\"Samba\"}");
 
@@ -55,7 +54,7 @@ public class PdfGeneratorProcessorTest {
 	}
 
 	@Test
-	public void emptyJsonReturnsStream() throws JsonProcessingException, IOException, PdfGeneratorException {
+	public void emptyJsonReturnsStream() throws IOException, PdfGeneratorException {
 		// Given
 		final JsonNode json = new ObjectMapper().readTree("{}");
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -7,6 +7,7 @@ server:
 ---
 spring:
   profiles: local
+---
 service:
   api:
     url: http://localhost:${server.port}/api/pdfGenerator


### PR DESCRIPTION
The original driver for this PR was a failing test in `ServiceControllerIT.java` that had assumed the output data items would be split using **LF** only.  Running the tests in a windows environment returns the data items **CRLF** delimited.

The split is now done with `System.lineSeparator()`

I've also added some cosmetic updates, removal of unused imports and a couple of syntax amendments.